### PR TITLE
Express as a Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Command | Description
 `yarn run prettier-check` | Prints the filenames of files that are different from Prettier formatting
 `yarn run start` | (alias of `yarn run start-dev`)
 
-**Note**: replace `yarn` with `npm` if you use npm.
+**Note**: replace `yarn` with `npm` in the `package.json` file if you use npm.
 
 ## See also
 * [React Webpack Typescript Starter](https://github.com/vikpe/react-webpack-typescript-starter)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 `yarn run start-prod`
 
 * Build app once (HMR disabled) to `/dist/`
-* App served @ `http://localhost:3000`
+* App served at the specified port from the envrionment variable `PORT`, otherwise @ `http://localhost:3000`
 
 ---
 
@@ -36,7 +36,7 @@
 Command | Description
 --- | ---
 `yarn run start-dev` | Build app continously (HMR enabled) and serve @ `http://localhost:8080`
-`yarn run start-prod` | Build app once (HMR disabled) to `/dist/` and serve @ `http://localhost:3000`
+`yarn run start-prod` | Build app once (HMR disabled) to `/dist/` and served at the specified port from the envrionment variable `PORT`, otherwise @ `http://localhost:3000`
 `yarn run build` | Build app to `/dist/`
 `yarn run test` | Run tests
 `yarn run prettier-write` | Format code and write changes

--- a/express.js
+++ b/express.js
@@ -1,6 +1,6 @@
 const express    = require('express');
 const app        = express();
-const portNumber = 3000;
+const portNumber = process.env.PORT || 3000;
 const sourceDir  = 'dist';
 
 app.use(express.static(sourceDir));

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "css-loader": "^3.0.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
-    "express": "^4.17.1",
     "file-loader": "^4.0.0",
     "html-webpack-plugin": "^3.2.0",
     "identity-obj-proxy": "^3.0.0",
@@ -65,5 +64,7 @@
     "webpack-dev-server": "^3.7.2",
     "webpack-merge": "^4.2.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "express": "^4.17.1"
+  }
 }


### PR DESCRIPTION
Hello Vikpe.

First, awesome repo. It is very similar to what I have going on privately. But I wanted to add a few things that I have discovered to be a bit more flexible for CI and deploying on containers.

My edits:
1. Express is now marked as a Dependency instead of a Dev Dependency.
   - Essentially this allows people to perform a `npm prune --production` to remove all of the dev dependencies on builds before they perform a release. This ensures a smaller disk size needed for any deployments, which is really nice for docker containers. Unfortunately, I have not found a [yarn equivalent to perform this](https://github.com/yarnpkg/yarn/issues/696) same action.
2. Made Express listen to an optional Environment Variable set for the Port
3. Added a bit more documentation

As a side note, if you accept this, I would happily do the same for your other repos listed in the README.

Feel free to add any questions 💯 
